### PR TITLE
Add file copy exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ module.exports = function(grunt) {
 			files: [{
 				expand: true,
 				cwd: './assets',
-				src: ['**/*.!(coffee|less|scss|sass)'], // Add scss and sass.
 				// Before: src: ['**/*.!(coffee|less)'],
-				// After:  src: ['**/*.!(coffee|less|scss|sass)'],
+				src: ['**/*.!(coffee|less|scss|sass)'],
 				dest: '.tmp/public'
 			}]
 		},

--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-sass');
 };
 ```
+* Edit `copy.js` in `tasks` > `config`, add file copy exclusions for SASS and SCSS:
+```javascript
+module.exports = function(grunt) {
+
+	grunt.config.set('copy', {
+		dev: {
+			files: [{
+				expand: true,
+				cwd: './assets',
+				src: ['**/*.!(coffee|less|scss|sass)'], // Add scss and sass.
+				// Before: src: ['**/*.!(coffee|less)'],
+				// After:  src: ['**/*.!(coffee|less|scss|sass)'],
+				dest: '.tmp/public'
+			}]
+		},
+		build: {
+			files: [{
+				expand: true,
+				cwd: '.tmp/public',
+				src: ['**/*'],
+				dest: 'www'
+			}]
+		}
+	});
+
+	grunt.loadNpmTasks('grunt-contrib-copy');
+};
+
+```
 * Add line `sass:dev` to `register` > `compileAssets.js`:
 ```javascript
 module.exports = function (grunt) {

--- a/tasks/config/copy.js
+++ b/tasks/config/copy.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
 			files: [{
 				expand: true,
 				cwd: './assets',
-				src: ['**/*.!(coffee|less)'],
+				src: ['**/*.!(coffee|less|scss|sass)'],
 				dest: '.tmp/public'
 			}]
 		},


### PR DESCRIPTION
Added instructions to README. Adding this prevents the copy task from copying `*.sass` and `*.scss` the same way it doesn't copy `*.coffee` and `*.less`.
